### PR TITLE
fix: replaced update with patch to improve update resilience

### DIFF
--- a/config/crd/bases/vpc.scaleway.com_networkinterfaces.yaml
+++ b/config/crd/bases/vpc.scaleway.com_networkinterfaces.yaml
@@ -79,9 +79,6 @@ spec:
               parentCidr:
                 description: ParentCIDR is the parent cidr of the Address
                 type: string
-            required:
-            - linkName
-            - macAddress
             type: object
         type: object
     served: true

--- a/config/rbac/node-role.yaml
+++ b/config/rbac/node-role.yaml
@@ -13,7 +13,7 @@ rules:
   verbs:
   - get
   - list
-  - update
+  - patch
   - watch
 - apiGroups:
   - vpc.scaleway.com
@@ -21,7 +21,7 @@ rules:
   - networkinterfaces/status
   verbs:
   - get
-  - update
+  - patch
 - apiGroups:
   - vpc.scaleway.com
   resources:

--- a/controllers/privatenetwork_controller.go
+++ b/controllers/privatenetwork_controller.go
@@ -124,8 +124,9 @@ func (r *PrivateNetworkReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 						return ctrl.Result{}, err
 					}
 				}
+				patch := client.MergeFrom(pn.DeepCopy())
 				controllerutil.RemoveFinalizer(pn, constants.FinalizerName)
-				if err := r.Update(ctx, pn); err != nil {
+				if err := r.Patch(ctx, pn, patch); err != nil {
 					log.Error(err, "failed to add finalizer")
 					return ctrl.Result{}, err
 				}
@@ -137,8 +138,9 @@ func (r *PrivateNetworkReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	}
 
 	if !controllerutil.ContainsFinalizer(pn, constants.FinalizerName) {
+		patch := client.MergeFrom(pn.DeepCopy())
 		controllerutil.AddFinalizer(pn, constants.FinalizerName)
-		if err := r.Update(ctx, pn); err != nil {
+		if err := r.Patch(ctx, pn, patch); err != nil {
 			log.Error(err, "failed to add finalizer")
 			return ctrl.Result{}, err
 		}
@@ -217,10 +219,11 @@ func (r *PrivateNetworkReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 				log.Error(err, "could not create networkInterface")
 				return ctrl.Result{RequeueAfter: RequeueDuration}, err
 			}
+			patch := client.MergeFrom(nic.DeepCopy())
 			nic.Status.MacAddress = privateNIC.MacAddress
-			err = r.Client.Status().Update(ctx, nic)
+			err = r.Client.Status().Patch(ctx, nic, patch)
 			if err != nil {
-				log.Error(err, "could not update networkInterface status")
+				log.Error(err, "could not patch networkInterface status")
 				return ctrl.Result{RequeueAfter: RequeueDuration}, err
 			}
 			log.Info(fmt.Sprintf("Successfully created networkInterface %s on node %s", nic.Name, node.Name))
@@ -279,8 +282,9 @@ func (r *PrivateNetworkReconciler) ReconcileDeprecated(req ctrl.Request) (ctrl.R
 						return ctrl.Result{}, err
 					}
 				}
+				patch := client.MergeFrom(pn.DeepCopy())
 				controllerutil.RemoveFinalizer(pn, constants.FinalizerName)
-				if err := r.Update(ctx, pn); err != nil {
+				if err := r.Patch(ctx, pn, patch); err != nil {
 					log.Error(err, "failed to add finalizer")
 					return ctrl.Result{}, err
 				}
@@ -292,8 +296,9 @@ func (r *PrivateNetworkReconciler) ReconcileDeprecated(req ctrl.Request) (ctrl.R
 	}
 
 	if !controllerutil.ContainsFinalizer(pn, constants.FinalizerName) {
+		patch := client.MergeFrom(pn.DeepCopy())
 		controllerutil.AddFinalizer(pn, constants.FinalizerName)
-		if err := r.Update(ctx, pn); err != nil {
+		if err := r.Patch(ctx, pn, patch); err != nil {
 			log.Error(err, "failed to add finalizer")
 			return ctrl.Result{}, err
 		}
@@ -379,10 +384,11 @@ func (r *PrivateNetworkReconciler) ReconcileDeprecated(req ctrl.Request) (ctrl.R
 				log.Error(err, "could not create networkInterface")
 				return ctrl.Result{RequeueAfter: RequeueDuration}, err
 			}
+			patch := client.MergeFrom(nic.DeepCopy())
 			nic.Status.MacAddress = privateNIC.MacAddress
-			err = r.Client.Status().Update(ctx, nic)
+			err = r.Client.Status().Patch(ctx, nic, patch)
 			if err != nil {
-				log.Error(err, "could not update networkInterface status")
+				log.Error(err, "could not patch networkInterface status")
 				return ctrl.Result{RequeueAfter: RequeueDuration}, err
 			}
 			log.Info(fmt.Sprintf("Successfully created networkInterface %s on node %s", nic.Name, node.Name))

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -139,12 +139,14 @@ func (c *ConfigMapIPAM) CreatePrefix(prefix goipam.Prefix) (goipam.Prefix, error
 	if err != nil {
 		return goipam.Prefix{}, err
 	}
+
+	patch := client.MergeFrom(cm.DeepCopy())
 	if cm.BinaryData == nil {
 		cm.BinaryData = make(map[string][]byte)
 	}
 	cm.BinaryData[getCmCIDR(prefix.Cidr)] = data
 
-	err = c.client.Update(context.Background(), cm)
+	err = c.client.Patch(context.Background(), cm, patch)
 	if err != nil {
 		return goipam.Prefix{}, err
 	}
@@ -218,9 +220,10 @@ func (c *ConfigMapIPAM) UpdatePrefix(prefix goipam.Prefix) (goipam.Prefix, error
 		return goipam.Prefix{}, err
 	}
 
+	patch := client.MergeFrom(cm.DeepCopy())
 	cm.BinaryData[getCmCIDR(prefix.Cidr)] = data
 
-	return prefix, c.client.Update(context.Background(), cm)
+	return prefix, c.client.Patch(context.Background(), cm, patch)
 }
 
 func (c *ConfigMapIPAM) DeletePrefix(prefix goipam.Prefix) (goipam.Prefix, error) {
@@ -236,7 +239,8 @@ func (c *ConfigMapIPAM) DeletePrefix(prefix goipam.Prefix) (goipam.Prefix, error
 	if !ok {
 		return prefix, nil
 	}
+	patch := client.MergeFrom(cm.DeepCopy())
 	delete(cm.BinaryData, getCmCIDR(prefix.Cidr))
 
-	return prefix, c.client.Update(context.Background(), cm)
+	return prefix, c.client.Patch(context.Background(), cm, patch)
 }


### PR DESCRIPTION
I replaced all instances of Update with Patch. This means that if the same object is updated by a different controller, it won't conflict.

This seems to fix #11. We will be deploying this change to our clusters and test the next couple of days.

Containers are available with this fix on Docker Hub. `wouter0100/scaleway-k8s-vpc:node-patch-debug-3` and `wouter0100/scaleway-k8s-vpc:controller-patch-debug`