### PR TITLE
Allow patching on networkinterfaces/status

### DIFF
--- a/config/rbac/controller-role.yaml
+++ b/config/rbac/controller-role.yaml
@@ -43,6 +43,7 @@ rules:
   - networkinterfaces/status
   verbs:
   - get
+  - patch
   - update
 - apiGroups:
   - vpc.scaleway.com


### PR DESCRIPTION
Having bumped to the latest version, it looks like we need to grant patch for networkinterfaces/status

`E0423 17:36:51.946896       1 controller.go:246] controller "msg"="Reconciler error" "error"="networkinterfaces.vpc.scaleway.com \"scaleway-k8s-vpc-dev-zj4s9\" is forbi │
│ dden: User \"system:serviceaccount:scaleway-k8s-vpc-system:scaleway-k8s-vpc-controller\" cannot patch resource \"networkinterfaces/status\" in API group \"vpc.scaleway. │
│ com\" at the cluster scope" "controller"="networkinterface" "name"="scaleway-k8s-vpc-dev-zj4s9" "namespace"="" "reconcilerGroup"="vpc.scaleway.com" "reconcilerKind"="Ne │
│ tworkInterface"`